### PR TITLE
Metal Storm projectile nerf

### DIFF
--- a/1.6/Defs/DamageDefs/Damages_Common.xml
+++ b/1.6/Defs/DamageDefs/Damages_Common.xml
@@ -38,10 +38,12 @@
     <defName>BEWH_BoltMetalStorm</defName>
     <label>shrapnel explosion</label>
     <workerClass>DamageWorker_Cut</workerClass>
-    <deathMessage>{0} discovered that the air itself can turn into shrapnel.</deathMessage>
+    <deathMessage>{0} was riddled with Metal Storm shrapnel.</deathMessage>
     <hediff>Cut</hediff>
     <hediffSolid>Crack</hediffSolid>
     <plantDamageFactor>10</plantDamageFactor>
+    <buildingDamageFactorImpassable Inherit="False">1.33</buildingDamageFactorImpassable>
+    <buildingDamageFactorPassable Inherit="False">0.66</buildingDamageFactorPassable>
     <explosionCellFleck>PlainFlash</explosionCellFleck>
     <explosionColorCenter>(30, 30, 30)</explosionColorCenter>
     <explosionColorEdge>(15, 15, 15)</explosionColorEdge>

--- a/1.6/Defs/ThingDefs_Weapons/ThingDef_Projectiles.xml
+++ b/1.6/Defs/ThingDefs_Weapons/ThingDef_Projectiles.xml
@@ -88,7 +88,6 @@
     <ThingDef ParentName="BaseBullet">
         <defName>BEWH_BolterShrapnel</defName>
         <label>Metal Storm Shrapnel</label>
-        <description>...</description>
         <thingClass>Projectile_Explosive</thingClass>
         <uiIconPath>Things/Ammo/Bolter/MetalStorm_Small</uiIconPath>
         <graphicData>
@@ -99,7 +98,7 @@
         <projectile>
             <damageDef>BEWH_BoltMetalStorm</damageDef>
             <damageAmountBase>16</damageAmountBase>
-            <armorPenetrationBase>0.48</armorPenetrationBase>
+            <armorPenetrationBase>0.23</armorPenetrationBase>
             <explosionRadius>1.25</explosionRadius>
             <soundExplode>GunShotA</soundExplode>
             <screenShakeFactor>0.1</screenShakeFactor>

--- a/1.6/Defs/ThingDefs_Weapons/ThingDef_ThunderWarriors.xml
+++ b/1.6/Defs/ThingDefs_Weapons/ThingDef_ThunderWarriors.xml
@@ -31,9 +31,8 @@
       </skillRequirements>
     </recipeMaker>
     <costList>
-      <Steel>68</Steel>
-      <Plasteel>10</Plasteel>
-      <ComponentIndustrial>10</ComponentIndustrial>
+      <Steel>67</Steel>
+      <ComponentIndustrial>5</ComponentIndustrial>
     </costList>
     <verbs>
       <li>


### PR DESCRIPTION
Metal storm's projectile shrapnel armor penetration reduced to 0.23 Metal storm's projectile shrapnel damage to buildings reduced to 1.33 impassable / 0.66 passable

Proto-bolter crafting cost reduced to 67 steel, component 5